### PR TITLE
Move panel to tool shelf

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following programs are necessary:
 
 1. Open an existing file, or create a new file and make sure it's saved in its own folder.
 2. Remove any global light sources.
-3. In the render properties tab on the right, click "Initialize / Repair" in the "RCT Graphics Helper" section.
+3. In the RCT Tools toolbar on the 3D view toolshelf, click "Initialize / Repair" in the "RCT Graphics Helper" section.
 4. This will create the lighting rig, and set the correct render settings.
 5. More options are now available in the RCT Graphics Helper section. Click the "Render" button to start rendering the scene.
 6. In the folder where the Blend file is saved, an "output" folder has been created with the rendered image files.

--- a/rct-graphics-helper/rct_graphics_helper_panel.py
+++ b/rct-graphics-helper/rct_graphics_helper_panel.py
@@ -21,13 +21,13 @@ from .operators.render_tiles_operator import RenderTiles
 
 from .models.palette import palette_colors, palette_colors_details
 
-
 class GraphicsHelperPanel(bpy.types.Panel):
+
     bl_label = "RCT Graphics Helper"
-    bl_idname = "RENDER_PT_rct_graphics_helper"
-    bl_space_type = 'PROPERTIES'
-    bl_region_type = 'WINDOW'
-    bl_context = "render"
+    bl_idname = "VIEW3D_PT_rct_graphics_helper"
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'TOOLS'
+    bl_category = 'RollerCoaster Tycoon'
 
     def draw(self, context):
 

--- a/rct-graphics-helper/rct_graphics_helper_panel.py
+++ b/rct-graphics-helper/rct_graphics_helper_panel.py
@@ -27,7 +27,7 @@ class GraphicsHelperPanel(bpy.types.Panel):
     bl_idname = "VIEW3D_PT_rct_graphics_helper"
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'TOOLS'
-    bl_category = 'RollerCoaster Tycoon'
+    bl_category = 'RCT Tools'
 
     def draw(self, context):
 


### PR DESCRIPTION
This un-buries the RCT helpers panel from the render properties panel and puts it in the "tool shelf" where it is easier to access.

![image](https://user-images.githubusercontent.com/3454156/208226159-f15a55f0-cda2-4ccf-8b75-9a94306d27fc.png)
