### PR TITLE
Implement new sprite groups

### DIFF
--- a/rct-graphics-helper/angle_sections/track.py
+++ b/rct-graphics-helper/angle_sections/track.py
@@ -1,5 +1,5 @@
 '''
-Copyright (c) 2022 RCT Graphics Helper developers
+Copyright (c) 2023 RCT Graphics Helper developers
 
 For a complete list of all authors, please refer to the addon's meta info.
 Interested in contributing? Visit https://github.com/oli414/Blender-RCT-Graphics
@@ -7,45 +7,47 @@ Interested in contributing? Visit https://github.com/oli414/Blender-RCT-Graphics
 RCT Graphics Helper is licensed under the GNU General Public License version 3.
 '''
 
-track_angle_sections_names = [
-    "VEHICLE_SPRITE_FLAG_FLAT",
-    "VEHICLE_SPRITE_FLAG_GENTLE_SLOPES",
-    "VEHICLE_SPRITE_FLAG_STEEP_SLOPES",
-    "VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES",
-    "VEHICLE_SPRITE_FLAG_DIAGONAL_SLOPES",
-    "VEHICLE_SPRITE_FLAG_FLAT_BANKED",
-    "VEHICLE_SPRITE_FLAG_INLINE_TWISTS",
-    "VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_BANKED_TRANSITIONS",
-    "VEHICLE_SPRITE_FLAG_DIAGONAL_GENTLE_SLOPE_BANKED_TRANSITIONS",
-    "VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TRANSITIONS",
-    "VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TURNS",
-    "VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_WHILE_BANKED_TRANSITIONS",
-    "VEHICLE_SPRITE_FLAG_CORKSCREWS",
-    "VEHICLE_SPRITE_FLAG_RESTRAINT_ANIMATION",
-    "VEHICLE_SPRITE_FLAG_CURVED_LIFT_HILL"
+# This is the order sprite groups are rendered in
+sprite_group_names = [
+    "slopeFlat",        "slopes12",           "slopes25",         "slopes42",         "slopes60",
+    "slopes75",         "slopes90",           "slopesLoop",       "slopeInverted",    "slopes8",
+    "slopes16",         "slopes50",           "flatBanked22",     "flatBanked45",     "flatBanked67",
+    "flatBanked90",     "inlineTwists",       "slopes12Banked22", "slopes8Banked22",  "slopes25Banked22",
+    "slopes25Banked45", "slopes12Banked45",   "slopes25Banked67", "slopes25Banked90", "slopes25InlineTwists",
+    "slopes42Banked22", "slopes42Banked45",   "slopes42Banked67", "slopes42Banked90", "slopes60Banked22",
+    "corkscrews",       "restraintAnimation", "curvedLiftHillUp", "curvedLiftHillDown"
 ]
 
-track_angle_sections = {
-    "VEHICLE_SPRITE_FLAG_FLAT": [
+# The sprites to render in each sprite group. The given rotation values are used in simple mode
+sprite_group_manifest = {
+    'slopeFlat': [
         [False, 32, 0, 0, 0]
     ],
-    "VEHICLE_SPRITE_FLAG_GENTLE_SLOPES": [
+    'slopes12': [
         [False, 4, 11.1026, 0, 0],
-        [False, 4, -11.1026, 0, 0],
+        [False, 4, -11.1026, 0, 0]
+    ],
+    'slopes25': [
         [False, 32, 22.2052, 0, 0],
         [False, 32, -22.2052, 0, 0]
     ],
-    "VEHICLE_SPRITE_FLAG_STEEP_SLOPES": [
+    'slopes42': [
         [False, 8, 40.36, 0, 0],
-        [False, 8, -40.36, 0, 0],
+        [False, 8, -40.36, 0, 0]
+    ],
+    'slopes60': [
         [False, 32, 58.5148, 0, 0],
         [False, 32, -58.5148, 0, 0]
     ],
-    "VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES": [
+    'slopes75': [
         [False, 4, 75, 0, 0],
-        [False, 4, -75, 0, 0],
+        [False, 4, -75, 0, 0]
+    ],
+    'slopes90': [
         [False, 32, 90, 0, 0],
-        [False, 32, -90, 0, 0],
+        [False, 32, -90, 0, 0]
+    ],
+    'slopesLoop': [
         [False, 4, 105, 0, 0],
         [False, 4, -105, 0, 0],
         [False, 4, 120, 0, 0],
@@ -55,29 +57,40 @@ track_angle_sections = {
         [False, 4, 150, 0, 0],
         [False, 4, -150, 0, 0],
         [False, 4, 165, 0, 0],
-        [False, 4, -165, 0, 0],
+        [False, 4, -165, 0, 0]
+    ],
+    'slopeInverted': [
         [False, 4, 180, 0, 0]
     ],
-    "VEHICLE_SPRITE_FLAG_DIAGONAL_SLOPES": [
+    'slopes8': [
         [True, 4, 8.0503, 0, 0],
-        [True, 4, -8.0503, 0, 0],
+        [True, 4, -8.0503, 0, 0]
+    ],
+    'slopes16': [
         [True, 4, 16.1005, 0, 0],
-        [True, 4, -16.1005, 0, 0],
+        [True, 4, -16.1005, 0, 0]
+    ],
+    'slopes50': [
         [True, 4, 49.1035, 0, 0],
         [True, 4, -49.1035, 0, 0]
     ],
-    "VEHICLE_SPRITE_FLAG_FLAT_BANKED": [
+    'flatBanked22': [
         [False, 8, 0, -22.5, 0],
-        [False, 8, 0, 22.5, 0],
+        [False, 8, 0, 22.5, 0]
+    ],
+    'flatBanked45': [
         [False, 32, 0, -45, 0],
         [False, 32, 0, 45, 0]
     ],
-    "VEHICLE_SPRITE_FLAG_INLINE_TWISTS": [
-        # The banking sprites are used at the start of a twist ((180-MAX_BANK)/6*FRAME)+MAX_BANK
+    'flatBanked67': [
         [False, 4, 0, -67.5, 0],
-        [False, 4, 0, 67.5, 0],
+        [False, 4, 0, 67.5, 0]
+    ],
+    'flatBanked90': [
         [False, 4, 0, -90, 0],
-        [False, 4, 0, 90, 0],
+        [False, 4, 0, 90, 0]
+    ],
+    'inlineTwists': [
         [False, 4, 0, -112.5, 0],
         [False, 4, 0, 112.5, 0],
         [False, 4, 0, -135, 0],
@@ -85,37 +98,93 @@ track_angle_sections = {
         [False, 4, 0, -157.5, 0],
         [False, 4, 0, 157.5, 0]
     ],
-    "VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_BANKED_TRANSITIONS": [
+    'slopes12Banked22': [
         [False, 32, 11.1026, -22.5, 0],
         [False, 32, 11.1026, 22.5, 0],
         [False, 32, -11.1026, -22.5, 0],
         [False, 32, -11.1026, 22.5, 0]
     ],
-    "VEHICLE_SPRITE_FLAG_DIAGONAL_GENTLE_SLOPE_BANKED_TRANSITIONS": [
+    'slopes8Banked22': [
         [True, 4, 8.0503, -22.5, 0],
         [True, 4, 8.0503, 22.5, 0],
         [True, 4, -8.0503, -22.5, 0],
         [True, 4, -8.0503, 22.5, 0]
     ],
-    "VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TRANSITIONS": [
+    'slopes25Banked22': [
         [False, 4, 22.2052, -22.5, 0],
         [False, 4, 22.2052, 22.5, 0],
         [False, 4, -22.2052, -22.5, 0],
         [False, 4, -22.2052, 22.5, 0]
     ],
-    "VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TURNS": [
+    'slopes25Banked45': [
         [False, 32, 22.2052, -45, 0],
         [False, 32, 22.2052, 45, 0],
         [False, 32, -22.2052, -45, 0],
         [False, 32, -22.2052, 45, 0]
     ],
-    "VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_WHILE_BANKED_TRANSITIONS": [
+    'slopes12Banked45': [
         [False, 4, 11.1026, -45, 0],
         [False, 4, 11.1026, 45, 0],
         [False, 4, -11.1026, -45, 0],
         [False, 4, -11.1026, 45, 0]
     ],
-    "VEHICLE_SPRITE_FLAG_CORKSCREWS": [
+    'slopes25Banked67': [
+        [False, 4, 22.2052, -67.5, 0],
+        [False, 4, 22.2052, 67.5, 0],
+        [False, 4, -22.2052, -67.5, 0],
+        [False, 4, -22.2052, 67.5, 0]
+    ],
+    'slopes25Banked90': [
+        [False, 4, 22.2052, -90, 0],
+        [False, 4, 22.2052, 90, 0],
+        [False, 4, -22.2052, -90, 0],
+        [False, 4, -22.2052, 90, 0]
+    ],
+    'slopes25InlineTwists': [
+        [False, 4, 22.2052, -112.5, 0],
+        [False, 4, 22.2052, 112.5, 0],
+        [False, 4, 22.2052, -135, 0],
+        [False, 4, 22.2052, 135, 0],
+        [False, 4, 22.2052, -157.5, 0],
+        [False, 4, 22.2052, 157.5, 0],
+        [False, 4, -22.2052, -112.5, 0],
+        [False, 4, -22.2052, 112.5, 0],
+        [False, 4, -22.2052, -135, 0],
+        [False, 4, -22.2052, 135, 0],
+        [False, 4, -22.2052, -157.5, 0],
+        [False, 4, -22.2052, 157.5, 0]
+    ],
+    'slopes42Banked22': [
+        [False, 8, 40.36, -22.5, 0],
+        [False, 8, 40.36, 22.5, 0],
+        [False, 8, -40.36, -22.5, 0],
+        [False, 8, -40.36, 22.5, 0]
+    ],
+    'slopes42Banked45': [
+        [False, 8, 40.36, -45, 0],
+        [False, 8, 40.36, 45, 0],
+        [False, 8, -40.36, -45, 0],
+        [False, 8, -40.36, 45, 0]
+    ],
+    'slopes42Banked67': [
+        [False, 8, 40.36, -67.5, 0],
+        [False, 8, 40.36, 67.5, 0],
+        [False, 8, -40.36,-67.5, 0],
+        [False, 8, -40.36, 67.5, 0]
+    ],
+    'slopes42Banked90': [
+        [False, 8, 40.36, -90, 0],
+        [False, 8, 40.36, 90, 0],
+        [False, 8, -40.36, -90, 0],
+        [False, 8, -40.36, 90, 0]
+    ],
+    'slopes60Banked22': [
+        [False, 32, 58.5148, -22.5, 0],
+        [False, 32, 58.5148, 22.5, 0],
+        [False, 32, -58.5148, -22.5, 0],
+        [False, 32, -58.5148, 22.5, 0]
+    ],
+    'corkscrews': [
         [False, 4, 22.21,   20.7,   4.11],
         [False, 4, 50.77,   37.76,  18.43],
         [False, 4, 90,      45,     45],
@@ -140,10 +209,120 @@ track_angle_sections = {
         [False, 4, -129.23,  37.76,  -71.57],
         [False, 4, -157.79,  20.7,   -85.89],
     ],
-    "VEHICLE_SPRITE_FLAG_RESTRAINT_ANIMATION": [
+    'restraintAnimation': [
         [False, 4, 0, 0, 0]
     ],
-    "VEHICLE_SPRITE_FLAG_CURVED_LIFT_HILL": [
+    'curvedLiftHillUp': [
+        [False, 32, 9.8287, 0, 0]
+    ],
+    'curvedLiftHillDown': [
         [False, 32, 9.8287, 0, 0]
     ]
+}
+
+# Default sprite precision for full mode, the tooltip for the sprite group, and if the sprite group should be hidden from the list of sprite groups
+sprite_group_metadata = {
+    "slopeFlat": [32, "Flat track"],
+    "slopes12": [4, "Orthogonal flat-to-gentle slope track"],
+    "slopes25": [32, "Orthogonal gentle slope track"],
+    "slopes42": [8, "Gentle-to-steep slope track"],
+    "slopes60": [32, "Orthogonal steep slope track"],
+    "slopes75": [4, "Steep-to-vertical slope track"],
+    "slopes90": [4, "Vertical track"],
+    "slopesLoop": [4,"Loop track"],
+    "slopeInverted": [4, "Fully inverted track"],
+    "slopes8": [4, "Diagonal flat-to-gentle slope track"],
+    "slopes16": [4, "Diagonal gentle slope track"],
+    "slopes50": [4, "Diagonal steep track"],
+    "flatBanked22": [8, "Flat-to-bank transition track"],
+    "flatBanked45": [32, "Flat banked track"],
+    "flatBanked67": [4, "Flat steep banked track"],
+    "flatBanked90": [4, "Flat vertically-banked track"],
+    "inlineTwists": [4, "Flat inline twists"],
+    "slopes12Banked22": [32, "Orthogonal flat-to-gentle-and-flat-to-banked transition track"],
+    "slopes8Banked22": [4, "Diagonal flat-to-gentle-and-flat-to-banked transition track"],
+    "slopes25Banked22": [4, "Orthogonal gentle slope flat-to-bank transition track"],
+    "slopes25Banked45": [32, "Gentle sloped banked turns"],
+    "slopes12Banked45": [4, "Orthogonal flat-to-gentle-slope banked transition track"],
+    "slopes25Banked67": [4, "Part of small zero-G rolls"],
+    "slopes25Banked90": [4, "Part of small zero-G rolls"],
+    "slopes25InlineTwists": [4, "Part of large zero-G roll"],
+    "slopes42Banked22": [4, "Part of large zero-G roll"],
+    "slopes42Banked45": [4, "Part of large zero-G roll"],
+    "slopes42Banked67": [4, "Part of large zero-G roll"],
+    "slopes42Banked90": [4, "Part of large zero-G roll"],
+    "slopes60Banked22": [4, "Part of large zero-G roll"],
+    "corkscrews": [4, "Corkscrew track"],
+    "restraintAnimation": [4, "Animated restraints"],
+    "curvedLiftHillUp": [32, "Sprial lifthill up track"],
+    "curvedLiftHillDown": [32, "Spiral lifthill down track"]
+}
+
+legacy_group_names = [
+    "VEHICLE_SPRITE_FLAG_FLAT",
+    "VEHICLE_SPRITE_FLAG_GENTLE_SLOPES",
+    "VEHICLE_SPRITE_FLAG_STEEP_SLOPES",
+    "VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES",
+    "VEHICLE_SPRITE_FLAG_DIAGONAL_SLOPES",
+    "VEHICLE_SPRITE_FLAG_FLAT_BANKED",
+    "VEHICLE_SPRITE_FLAG_INLINE_TWISTS",
+    "VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_BANKED_TRANSITIONS",
+    "VEHICLE_SPRITE_FLAG_DIAGONAL_GENTLE_SLOPE_BANKED_TRANSITIONS",
+    "VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TRANSITIONS",
+    "VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TURNS",
+    "VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_WHILE_BANKED_TRANSITIONS",
+    "VEHICLE_SPRITE_FLAG_CORKSCREWS",
+    "VEHICLE_SPRITE_FLAG_RESTRAINT_ANIMATION",
+    "VEHICLE_SPRITE_FLAG_CURVED_LIFT_HILL",
+    "VEHICLE_SPRITE_FLAG_ZERO_G_ROLLS"
+]
+
+# Display name of each sprite group, tooltip for each sprite group, default state of each sprite group
+legacy_group_metadata = {
+    "VEHICLE_SPRITE_FLAG_FLAT": ["Flat", "Render sprites for flat track", True],
+    "VEHICLE_SPRITE_FLAG_GENTLE_SLOPES": ["Gentle Slopes", "Render sprites for gentle sloped track", True],
+    "VEHICLE_SPRITE_FLAG_STEEP_SLOPES": ["Steep Slopes", "Render sprites for steep sloped track", False],
+    "VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES": ["Vertical Loops", "Render sprites for vertical slopes and loops", False],
+    "VEHICLE_SPRITE_FLAG_DIAGONAL_SLOPES": ["Diagonal Slopes", "Render sprites for diagonal slopes", True],
+    "VEHICLE_SPRITE_FLAG_FLAT_BANKED": ["Flat Banked","Render sprites for flat banked track", False],
+    "VEHICLE_SPRITE_FLAG_INLINE_TWISTS": ["Inline Twist", "Render sprites for the inline twist element", False],
+    "VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_BANKED_TRANSITIONS": ["", "", False],
+    "VEHICLE_SPRITE_FLAG_DIAGONAL_GENTLE_SLOPE_BANKED_TRANSITIONS": ["", "", False],
+    "VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TRANSITIONS": ["", "", False],
+    "VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TURNS": ["Sloped Banked Turns","Render sprites for sloped banked turns", False],
+    "VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_WHILE_BANKED_TRANSITIONS": ["", "", False],
+    "VEHICLE_SPRITE_FLAG_CORKSCREWS": ["Corkscrew", "Render sprites for corkscrews", False],
+    "VEHICLE_SPRITE_FLAG_RESTRAINT_ANIMATION": ["Animated Restraints", "Render animated restraints", False],
+    "VEHICLE_SPRITE_FLAG_CURVED_LIFT_HILL": ["Spiral Lifthill", "Render sprites for spiral lifthills", False],
+    "VEHICLE_SPRITE_FLAG_ZERO_G_ROLLS": ["Zero-G Rolls", "Render sprites for zero-G rolls", False]
+}
+
+# What full sprite groups each legacy group maps to
+legacy_group_map = {
+    'VEHICLE_SPRITE_FLAG_FLAT': [ 'slopeFlat' ],
+    'VEHICLE_SPRITE_FLAG_GENTLE_SLOPES': ['slopes12', 'slopes25'],
+    'VEHICLE_SPRITE_FLAG_STEEP_SLOPES': ['slopes42', 'slopes60'],
+    'VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES': ['slopes75', 'slopes90', 'slopesLoop','slopeInverted'],
+    'VEHICLE_SPRITE_FLAG_DIAGONAL_SLOPES': ['slopes8', 'slopes16','slopes50'],
+    'VEHICLE_SPRITE_FLAG_FLAT_BANKED': ['flatBanked22','flatBanked45'],
+    'VEHICLE_SPRITE_FLAG_INLINE_TWISTS': ['flatBanked67', 'flatBanked90', 'inlineTwists'],
+    'VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_BANKED_TRANSITIONS': ['slopes12Banked22'],
+    'VEHICLE_SPRITE_FLAG_DIAGONAL_GENTLE_SLOPE_BANKED_TRANSITIONS': ['slopes8Banked22'],
+    'VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TRANSITIONS': ['slopes25Banked22'],
+    'VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TURNS': ['slopes25Banked45'],
+    'VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_WHILE_BANKED_TRANSITIONS': ['slopes12Banked45'],
+    'VEHICLE_SPRITE_FLAG_CORKSCREWS': ['corkscrews'],
+    'VEHICLE_SPRITE_FLAG_RESTRAINT_ANIMATION': ['restraintAnimation'],
+    'VEHICLE_SPRITE_FLAG_CURVED_LIFT_HILL': ['curvedLiftHillUp', 'curvedLiftHillDown'],
+    'VEHICLE_SPRITE_FLAG_ZERO_G_ROLLS': ["slopes60Banked22", "slopes42Banked22","slopes42Banked45","slopes42Banked67","slopes42Banked90", "slopes25InlineTwists", "slopes25Banked67","slopes25Banked90"]
+}
+
+# What legacy groups are implied by combinations of other legacy sprite groups
+legacy_group_implications = {
+    frozenset({'VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TURNS'}): frozenset({'VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TRANSITIONS','VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_WHILE_BANKED_TRANSITIONS','VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_BANKED_TRANSITIONS'}),
+    frozenset({'VEHICLE_SPRITE_FLAG_FLAT_BANKED','VEHICLE_SPRITE_FLAG_GENTLE_SLOPES'}): frozenset({'VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_BANKED_TRANSITIONS'}),
+    frozenset({'VEHICLE_SPRITE_FLAG_FLAT_BANKED','VEHICLE_SPRITE_FLAG_DIAGONAL_SLOPES'}): frozenset({'VEHICLE_SPRITE_FLAG_DIAGONAL_GENTLE_SLOPE_BANKED_TRANSITIONS'}),
+    frozenset({'VEHICLE_SPRITE_FLAG_INLINE_TWISTS'}): frozenset({'VEHICLE_SPRITE_FLAG_FLAT_BANKED', 'VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES'}),
+    frozenset({'VEHICLE_SPRITE_FLAG_CORKSCREWS'}): frozenset({'VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES'}),
+    frozenset({'VEHICLE_SPRITE_FLAG_ZERO_G_ROLLS'}): frozenset({'VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TURNS', 'VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TRANSITIONS', 'VEHICLE_SPRITE_FLAG_GENTLE_SLOPES', 'VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES'})
 }

--- a/rct-graphics-helper/operators/vehicle_render_operator.py
+++ b/rct-graphics-helper/operators/vehicle_render_operator.py
@@ -1,5 +1,5 @@
 '''
-Copyright (c) 2022 RCT Graphics Helper developers
+Copyright (c) 2023 RCT Graphics Helper developers
 
 For a complete list of all authors, please refer to the addon's meta info.
 Interested in contributing? Visit https://github.com/oli414/Blender-RCT-Graphics
@@ -12,7 +12,7 @@ import math
 import os
 
 from ..operators.render_operator import RCTRender
-from ..angle_sections.track import track_angle_sections, track_angle_sections_names
+from ..angle_sections.track import sprite_group_names, sprite_group_manifest
 
 
 class RenderVehicle(RCTRender, bpy.types.Operator):
@@ -57,67 +57,38 @@ class RenderVehicle(RCTRender, bpy.types.Operator):
 
         return self.task_builder.create_task(context)
 
-    def key_is_property(self, key, props):
-        for sprite_track_flagset in props.sprite_track_flags_list:
-            if sprite_track_flagset.section_id == key:
-                return True
-
-    def property_value(self, key, props):
-        i = 0
-        for sprite_track_flagset in props.sprite_track_flags_list:
-            if sprite_track_flagset.section_id == key:
-                return props.sprite_track_flags[i]
-            i += 1
-
-    def should_render_feature(self, key, context):
-        props = context.scene.rct_graphics_helper_vehicle_properties
-
-        inverted = False
-        if self.key_is_property(key, props):
-            if self.property_value(key, props):
-                return True
-        elif key == "VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TURNS" or key == "VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TRANSITIONS":
-            if self.property_value("SLOPED_TURNS", props):
-                return True
-        elif key == "VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_WHILE_BANKED_TRANSITIONS":
-            if self.property_value("SLOPED_TURNS", props) and self.property_value("VEHICLE_SPRITE_FLAG_FLAT_BANKED", props):
-                return True
-        elif key == "VEHICLE_SPRITE_FLAG_DIAGONAL_GENTLE_SLOPE_BANKED_TRANSITIONS":
-            if self.property_value("VEHICLE_SPRITE_FLAG_FLAT_BANKED", props) and self.property_value("VEHICLE_SPRITE_FLAG_DIAGONAL_SLOPES", props):
-                return True
-        elif key == "VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_BANKED_TRANSITIONS":
-            if self.property_value("VEHICLE_SPRITE_FLAG_FLAT_BANKED", props) and self.property_value("VEHICLE_SPRITE_FLAG_GENTLE_SLOPES", props):
-                return True
-        elif key == "VEHICLE_SPRITE_FLAG_RESTRAINT_ANIMATION" and inverted == False:
-            if props.restraint_animation:
-                return True
-        return False
-
     def add_render_angles(self, context, is_inverted=False, animation_frames=1):
+        properties = context.scene.rct_graphics_helper_vehicle_properties
         extra_roll = 0
         if is_inverted:
             extra_roll = 180
 
-        for i in range(len(track_angle_sections_names)):
-            key = track_angle_sections_names[i]
-            if self.should_render_feature(key, context):
-                track_sections = track_angle_sections[key]
-                for track_section in track_sections:
+        for sprite_group_name in sprite_group_names:
+            track_sections = sprite_group_manifest[sprite_group_name]
 
-                    base_view_angle = 0
-                    if track_section[0]:
-                        base_view_angle = 45
-                    self.task_builder.set_rotation(
-                        base_view_angle, -track_section[3] + extra_roll, track_section[2], track_section[4])
+            if sprite_group_name not in properties:
+                continue
+            precision = int(properties[sprite_group_name])
+            if precision == 0:
+                continue
 
-                    if key == "VEHICLE_SPRITE_FLAG_RESTRAINT_ANIMATION":
-                        for j in range(3):
-                            for k in range(track_section[1]):
-                                for l in range(animation_frames):
-                                    self.task_builder.set_rotation(
-                                        base_view_angle + k / track_section[1] * 360, -track_section[3] + extra_roll, track_section[2], track_section[4])
-                                    self.task_builder.add_viewing_angles(
-                                        1, animation_frames + j, 1)
-                    else:
-                        self.task_builder.add_viewing_angles(
-                            track_section[1], 0, animation_frames)
+            for track_section in track_sections:
+                # If the sprite angle is intended to be diagonal, offset by 45 degrees unless diagonal sprites will be present
+                base_view_angle = 0
+                if track_section[0] and precision < 8:
+                    base_view_angle = 45
+
+                self.task_builder.set_rotation(
+                    base_view_angle, -track_section[3] + extra_roll, track_section[2], track_section[4])
+
+                if sprite_group_name == "restraintAnimation":
+                    for j in range(3):
+                        for k in range(precision):
+                            for l in range(animation_frames):
+                                self.task_builder.set_rotation(
+                                    base_view_angle + k / precision * 360, -track_section[3] + extra_roll, track_section[2], track_section[4])
+                                self.task_builder.add_viewing_angles(
+                                    1, animation_frames + j, 1)
+                else:
+                    self.task_builder.add_viewing_angles(
+                        precision, 0, animation_frames)

--- a/rct-graphics-helper/rct_graphics_helper_panel.py
+++ b/rct-graphics-helper/rct_graphics_helper_panel.py
@@ -1,5 +1,5 @@
 '''
-Copyright (c) 2022 RCT Graphics Helper developers
+Copyright (c) 2023 RCT Graphics Helper developers
 
 For a complete list of all authors, please refer to the addon's meta info.
 Interested in contributing? Visit https://github.com/oli414/Blender-RCT-Graphics
@@ -20,6 +20,7 @@ from .operators.walls_render_operator import RenderWalls
 from .operators.render_tiles_operator import RenderTiles
 
 from .models.palette import palette_colors, palette_colors_details
+from .angle_sections.track import sprite_group_names, legacy_group_names
 
 class GraphicsHelperPanel(bpy.types.Panel):
 
@@ -170,25 +171,46 @@ class GraphicsHelperPanel(bpy.types.Panel):
             text = "Failed"
         row.operator("render.rct_walls", text=text)
 
+    legacy_group_display_order = [
+        "VEHICLE_SPRITE_FLAG_FLAT",
+        "VEHICLE_SPRITE_FLAG_GENTLE_SLOPES",
+        "VEHICLE_SPRITE_FLAG_STEEP_SLOPES",
+        "VEHICLE_SPRITE_FLAG_DIAGONAL_SLOPES",
+        "VEHICLE_SPRITE_FLAG_FLAT_BANKED",
+        "VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TURNS",
+        "VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES",
+        "VEHICLE_SPRITE_FLAG_INLINE_TWISTS",
+        "VEHICLE_SPRITE_FLAG_CORKSCREWS",
+        "VEHICLE_SPRITE_FLAG_ZERO_G_ROLLS",
+        "VEHICLE_SPRITE_FLAG_CURVED_LIFT_HILL",
+        "VEHICLE_SPRITE_FLAG_RESTRAINT_ANIMATION"
+    ]
+
     def draw_vehicle_panel(self, scene, layout):
         properties = scene.rct_graphics_helper_vehicle_properties
         general_properties = scene.rct_graphics_helper_general_properties
 
+        row = layout.row()
+        row.prop(properties,"sprite_group_mode")
+
         box = layout.box()
-
-        row = box.row()
-        row.label("Ride Vehicle Track Properties:")
-
-        split = box.split(.50)
+        split = box.split(0.5)
         columns = [split.column(), split.column()]
         i = 0
-        for sprite_track_flagset in properties.sprite_track_flags_list:
-            columns[i % 2].row().prop(properties, "sprite_track_flags",
-                                      index=i, text=sprite_track_flagset.name)
-            i += 1
-
-        row = layout.row()
-        row.prop(properties, "restraint_animation")
+        if properties.sprite_group_mode == "SIMPLE":
+            for legacy_group_name in self.legacy_group_display_order:
+                sprite_track_flagset = properties.legacy_spritegroups[legacy_group_name]
+                index = legacy_group_names.index(legacy_group_name)
+                columns[i % 2].row().prop(properties, "sprite_track_flags",
+                                          index=index, text=sprite_track_flagset.name, description = sprite_track_flagset.description)
+                i += 1
+        else:
+            columns = [column.split(0.667) for column in columns]
+            subcolumns = [columns[0].column(), columns[0].column(),columns[1].column(), columns[1].column()]
+            for sprite_group_name in sprite_group_names:
+                subcolumns[(i * 2) % 4].row().label(sprite_group_name+":")
+                subcolumns[(i * 2 + 1) % 4].row().prop(properties, sprite_group_name, text = "")
+                i += 1
 
         row = layout.row()
         row.prop(properties, "inverted_set")


### PR DESCRIPTION
Adding my sprite groups refactor to this tool. The general mode of operation is when activating or deactivating simple sprite groups, the `legacy_group_implications` enables additional sprite groups based on what is currently enabled, or disables sprite groups if their constituents are not enabled. After the implication phase, the new sprite groups are enabled or disabled based on `legacy_group_map` and the default precision in `sprite_group_metadata`. If the user switches from full to simple mode, the disable-enable code is run again, to prevent the project state from being different than what the options say.

Todo:
- [ ] Add implication function
- [ ] Add map function
- [ ] Add "copy to clipboard" function